### PR TITLE
removed .next() from date picker as it is not needed

### DIFF
--- a/cypress/integration/create-market-specs.js
+++ b/cypress/integration/create-market-specs.js
@@ -187,9 +187,6 @@ describe("Create market page", () => {
         createForm.elements.tagNorthAmerica().eq(1).click();
       createForm.elements.marketEndsLabel().should("be.visible");
       createForm.elements.marketEndsOption().should("be.visible");
-      createForm.elements.calendericon().should("be.visible").click();
-      createForm.elements.currentDate().next().should("be.visible").click();
-      createForm.elements.outcomesLabel().click({ force: true });
       createForm.elements
         .multipleOutcomes()
         // .scrollIntoView()
@@ -279,9 +276,6 @@ describe("Create market page", () => {
         createForm.elements.tagNorthAmerica().eq(1).click();
       createForm.elements.marketEndsLabel().should("be.visible");
       createForm.elements.marketEndsOption().should("be.visible");
-      createForm.elements.calendericon().should("be.visible").click();
-      // createForm.elements.currentDate().next().should("be.visible").click();
-      createForm.elements.outcomesLabel().click({ force: true });
       createForm.elements
         .multipleOutcomes()
         .scrollIntoView()
@@ -364,9 +358,6 @@ describe("Create market page", () => {
         createForm.elements.tagNorthAmerica().eq(1).click();
       createForm.elements.marketEndsLabel().should("be.visible");
       createForm.elements.marketEndsOption().should("be.visible");
-      createForm.elements.calendericon().should("be.visible").click();
-      // createForm.elements.currentDate().next().should("be.visible").click();
-      createForm.elements.outcomesLabel().click({ force: true });
       createForm.elements
         .multipleOutcomes()
         .scrollIntoView()
@@ -440,9 +431,6 @@ describe("Create market page", () => {
         createForm.elements.tagNorthAmerica().eq(1).click();
       createForm.elements.marketEndsLabel().should("be.visible");
       createForm.elements.marketEndsOption().should("be.visible");
-      createForm.elements.calendericon().should("be.visible").click();
-      // createForm.elements.currentDate().next().should("be.visible").click();
-      createForm.elements.outcomesLabel().click({ force: true });
       createForm.elements
         .outcomesSwitch().eq(0)
         .scrollIntoView()
@@ -518,9 +506,6 @@ describe("Create market page", () => {
         createForm.elements.tagNorthAmerica().eq(1).click();
       createForm.elements.marketEndsLabel().should("be.visible");
       createForm.elements.marketEndsOption().should("be.visible");
-      createForm.elements.calendericon().should("be.visible").click();
-      // createForm.elements.currentDate().next().should("be.visible").click();
-      createForm.elements.outcomesLabel().click({ force: true });
       createForm.elements
         .outcomesSwitch().eq(0)
         .scrollIntoView()
@@ -585,9 +570,6 @@ describe("Create market page", () => {
         createForm.elements.tagNorthAmerica().eq(1).click();
       createForm.elements.marketEndsLabel().should("be.visible");
       createForm.elements.marketEndsOption().should("be.visible");
-      createForm.elements.calendericon().should("be.visible").click();
-      // createForm.elements.currentDate().next().should("be.visible").click();
-      createForm.elements.outcomesLabel().click({ force: true });
       createForm.elements
         .outcomesSwitch().eq(0)
         .scrollIntoView()


### PR DESCRIPTION
I have removed .next() for date picker as it is not needed. 
Verified the test cases are working for the following days using clock mock in cypress

- last day of week in date picker (Saturday) 
- last day of month in date picker (30th jun 2022)
- last day of year in date picker (31st dec)

`git checkout 00aa9da1e4ab4e90b91efd64107789db0b138deb` is the commit from where I have created this branch.