### PR TITLE
Safe url query parsing and prevent submit

### DIFF
--- a/components/ui/TransactionButton.tsx
+++ b/components/ui/TransactionButton.tsx
@@ -5,6 +5,7 @@ import { useUserStore } from "lib/stores/UserStore";
 import { useAccountModals } from "lib/hooks/account";
 
 interface TransactionButtonProps {
+  preventDefault?: boolean;
   onClick: (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   disabled?: boolean;
   className?: string;
@@ -12,7 +13,14 @@ interface TransactionButtonProps {
 }
 
 const TransactionButton: FC<TransactionButtonProps> = observer(
-  ({ onClick, disabled = false, className = "", dataTest = "", children }) => {
+  ({
+    onClick,
+    disabled = false,
+    className = "",
+    dataTest = "",
+    children,
+    preventDefault,
+  }) => {
     const store = useStore();
     const { wallets } = store;
     const { connected } = wallets;
@@ -20,6 +28,9 @@ const TransactionButton: FC<TransactionButtonProps> = observer(
     const { locationAllowed } = useUserStore();
 
     const click = (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      if (preventDefault) {
+        event.preventDefault();
+      }
       if (!connected) {
         accountModals.openWalletSelect();
       } else {

--- a/lib/hooks/useMarketsUrlQuery.ts
+++ b/lib/hooks/useMarketsUrlQuery.ts
@@ -20,7 +20,13 @@ export const useMarketsUrlQuery = (): MarketListQuery & {
   const router = useRouter();
   const rawQuery = router.query;
 
-  const query = useMemo(() => parse(rawQuery), [rawQuery]);
+  const query = useMemo(() => {
+    try {
+      return parse(rawQuery);
+    } catch (error) {
+      return defaultQueryState;
+    }
+  }, [rawQuery]);
 
   const updateQuery = useCallback<MarketListQueryUpdater>(
     (update) => {

--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -619,10 +619,10 @@ const CreatePage: NextPage = observer(() => {
 
         <div className="flex justify-center mb-ztg-10 mt-ztg-12 w-full h-ztg-40">
           <TransactionButton
+            preventDefault
             className="w-ztg-266 ml-ztg-8 center flex-shrink-0"
             dataTest="createMarketSubmitButton"
             onClick={(e) => {
-              e.preventDefault();
               form.onSubmit(e);
               createMarket();
             }}


### PR DESCRIPTION
Fixes a couple of issues:
* The submit button on the create market page did not respect preventDefault when wallet not connected and old school submit the form and refresh the page.
* Url query parsing would fail sometimes with unrecognized params.