### PR TITLE
Allow numbers with decimals for scalar market bounds

### DIFF
--- a/components/create/OutcomesField.tsx
+++ b/components/create/OutcomesField.tsx
@@ -407,7 +407,6 @@ export const RangeOutcomeField: FC<{
               value={minStr}
               min={0}
               max={1}
-              step={step}
               onChange={(e) => {
                 changeMinimum(e.target.value);
               }}

--- a/components/markets/ScalarPriceRange.tsx
+++ b/components/markets/ScalarPriceRange.tsx
@@ -54,8 +54,9 @@ const ScalarPriceRange = observer(
       const pos =
         (upperBound - lowerBound) * ((1 - shortPrice + longPrice) / 2) +
         lowerBound;
+      const decimals = pos > 10 ? 0 : 3;
       return inferedType === "number"
-        ? pos.toFixed(0)
+        ? pos.toFixed(decimals)
         : moment(pos).format(dateFormat);
     }, [upperBound, lowerBound, shortPrice, longPrice]);
 

--- a/lib/stores/MarketStore.ts
+++ b/lib/stores/MarketStore.ts
@@ -295,11 +295,16 @@ class MarketStore {
   get bounds(): [number, number] | null {
     if (this.market.marketType.isScalar) {
       const bounds = this.market.marketType.asScalar;
-      return [Number(bounds[0].toString()), Number(bounds[1].toString())];
+      return [
+        Number(bounds[0].toString()) / ZTG,
+        Number(bounds[1].toString()) / ZTG,
+      ];
       //@ts-ignore - marketType is inconsistent
     } else if (this.market.marketType.scalar) {
       //@ts-ignore
-      return this.market.marketType.scalar;
+      const bounds = this.market.marketType.scalar;
+
+      return [Number(bounds[0]) / ZTG, Number(bounds[1]) / ZTG];
     } else {
       return null;
     }

--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -452,7 +452,7 @@ const CreatePage: NextPage = observer(() => {
           Categorical: outcomes.length,
         }
       : {
-          Scalar: [outcomes.minimum, outcomes.maximum],
+          Scalar: [outcomes.minimum * ZTG, outcomes.maximum * ZTG],
         };
 
     const deadlines = getMarketDeadlines();

--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -447,13 +447,8 @@ const CreatePage: NextPage = observer(() => {
     const metadata = getMarketMetadata();
 
     const outcomes = formData.outcomes.value;
-    const marketType = isMultipleOutcomeEntries(outcomes)
-      ? {
-          Categorical: outcomes.length,
-        }
-      : {
-          Scalar: [outcomes.minimum * ZTG, outcomes.maximum * ZTG],
-        };
+    const marketType = getMarketType(outcomes);
+    console.log(marketType);
 
     const deadlines = getMarketDeadlines();
 
@@ -469,6 +464,19 @@ const CreatePage: NextPage = observer(() => {
       metadata,
       callbackOrPaymentInfo,
     };
+  };
+
+  const getMarketType = (outcomes: Outcomes) => {
+    return isMultipleOutcomeEntries(outcomes)
+      ? {
+          Categorical: outcomes.length,
+        }
+      : {
+          Scalar: [
+            Number((outcomes.minimum * ZTG).toFixed(0)),
+            Number((outcomes.maximum * ZTG).toFixed(0)),
+          ],
+        };
   };
 
   const getCreateCpmmMarketAndAddPoolParameters = async (
@@ -498,14 +506,7 @@ const CreatePage: NextPage = observer(() => {
       Number([...poolRows].pop().amount) * ZTG
     ).toString();
 
-    const marketType = isMultipleOutcomeEntries(formData.outcomes.value)
-      ? { Categorical: numOutcomes }
-      : {
-          Scalar: [
-            formData.outcomes.value.minimum,
-            formData.outcomes.value.maximum,
-          ],
-        };
+    const marketType = getMarketType(formData.outcomes.value);
 
     const deadlines = getMarketDeadlines();
 

--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -448,7 +448,6 @@ const CreatePage: NextPage = observer(() => {
 
     const outcomes = formData.outcomes.value;
     const marketType = getMarketType(outcomes);
-    console.log(marketType);
 
     const deadlines = getMarketDeadlines();
 

--- a/pages/markets/[marketid].tsx
+++ b/pages/markets/[marketid].tsx
@@ -123,7 +123,7 @@ const Market: NextPage<{
 
   useEffect(() => {
     if (marketStore == null) return;
-    if (marketStore.scalarType === "date") {
+    if (marketStore.type === "scalar") {
       const observables = marketStore.marketOutcomes
         .filter((o) => o.metadata !== "ztg")
         .map((outcome) => {


### PR DESCRIPTION
[closes #471]

Also displays scalar prices for all scalar markets on market page

Needs to be in main branch to support runtime version 0.3.7

