### PR TITLE
Remove carousel card hiding logic for now

### DIFF
--- a/components/markets/MarketScroll.tsx
+++ b/components/markets/MarketScroll.tsx
@@ -19,6 +19,7 @@ const MarketScroll = observer(
     const scrollMax = cardWidth * markets.length + gap * (markets.length - 1);
     const cardsShown = Math.floor(containerWidth / (gap + cardWidth));
     const moveSize = cardsShown * (cardWidth + gap);
+    console.log(containerWidth);
 
     useEffect(() => {
       if (typeof window === "undefined") return;
@@ -29,6 +30,7 @@ const MarketScroll = observer(
       const observer = new IntersectionObserver(
         (entries) => {
           entries.forEach((entry) => {
+            console.log(entry);
             if (entry.isIntersecting) {
               entry.target.classList.remove("opacity-0");
             } else {
@@ -42,14 +44,16 @@ const MarketScroll = observer(
       cards.forEach((card) => {
         observer.observe(card);
       });
+    }, []);
 
-      return () => observer.disconnect();
-    }, [
-      store.leftDrawerClosed,
-      store.rightDrawerClosed,
-      store.leftDrawerAnimating,
-      store.rightDrawerAnimating,
-    ]);
+    useEffect(() => {
+      console.log("remove classes");
+
+      const cards = document.querySelectorAll(".market-card");
+      cards.forEach((card) => {
+        card.classList.remove("opacity-0");
+      });
+    }, [store.leftDrawerClosed, store.rightDrawerClosed]);
 
     const handleRightClick = () => {
       setScrollLeft((prev) => {

--- a/components/markets/MarketScroll.tsx
+++ b/components/markets/MarketScroll.tsx
@@ -9,7 +9,6 @@ import MarketCard, { IndexedMarketCardData } from "./market-card";
 
 const MarketScroll = observer(
   ({ title, markets }: { title: string; markets: IndexedMarketCardData[] }) => {
-    const store = useStore();
     const scrollRef = useRef<HTMLDivElement>();
     const [scrollLeft, setScrollLeft] = useState(0);
     const { width: containerWidth, ref: containerRef } = useResizeDetector();
@@ -19,41 +18,38 @@ const MarketScroll = observer(
     const scrollMax = cardWidth * markets.length + gap * (markets.length - 1);
     const cardsShown = Math.floor(containerWidth / (gap + cardWidth));
     const moveSize = cardsShown * (cardWidth + gap);
-    console.log(containerWidth);
 
-    useEffect(() => {
-      if (typeof window === "undefined") return;
-      if (window.innerWidth < 640) return;
+    // useEffect(() => {
+    //   if (typeof window === "undefined") return;
+    //   if (window.innerWidth < 640) return;
 
-      const cards = document.querySelectorAll(".market-card");
+    // const cards = document.querySelectorAll(".market-card");
 
-      const observer = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((entry) => {
-            console.log(entry);
-            if (entry.isIntersecting) {
-              entry.target.classList.remove("opacity-0");
-            } else {
-              entry.target.classList.add("opacity-0");
-            }
-          });
-        },
-        { root: containerRef.current, threshold: 0.7 },
-      );
+    // const observer = new IntersectionObserver(
+    //   (entries) => {
+    //     entries.forEach((entry) => {
+    //       console.log(entry);
+    //       if (entry.isIntersecting) {
+    //         entry.target.classList.remove("opacity-0");
+    //       } else {
+    //         entry.target.classList.add("opacity-0");
+    //       }
+    //     });
+    //   },
+    //   { root: containerRef.current },
+    // );
 
-      cards.forEach((card) => {
-        observer.observe(card);
-      });
-    }, []);
+    // cards.forEach((card) => {
+    //   observer.observe(card);
+    // });
+    // }, []);
 
-    useEffect(() => {
-      console.log("remove classes");
-
-      const cards = document.querySelectorAll(".market-card");
-      cards.forEach((card) => {
-        card.classList.remove("opacity-0");
-      });
-    }, [store.leftDrawerClosed, store.rightDrawerClosed]);
+    // useEffect(() => {
+    //   const cards = document.querySelectorAll(".market-card");
+    //   cards.forEach((card) => {
+    //     card.classList.remove("opacity-0");
+    //   });
+    // }, [store.leftDrawerClosed, store.rightDrawerClosed]);
 
     const handleRightClick = () => {
       setScrollLeft((prev) => {

--- a/components/markets/MarketScroll.tsx
+++ b/components/markets/MarketScroll.tsx
@@ -1,4 +1,5 @@
 import { motion } from "framer-motion";
+import { useStore } from "lib/stores/Store";
 import { observer } from "mobx-react";
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
@@ -8,6 +9,7 @@ import MarketCard, { IndexedMarketCardData } from "./market-card";
 
 const MarketScroll = observer(
   ({ title, markets }: { title: string; markets: IndexedMarketCardData[] }) => {
+    const store = useStore();
     const scrollRef = useRef<HTMLDivElement>();
     const [scrollLeft, setScrollLeft] = useState(0);
     const { width: containerWidth, ref: containerRef } = useResizeDetector();
@@ -40,7 +42,14 @@ const MarketScroll = observer(
       cards.forEach((card) => {
         observer.observe(card);
       });
-    }, []);
+
+      return () => observer.disconnect();
+    }, [
+      store.leftDrawerClosed,
+      store.rightDrawerClosed,
+      store.leftDrawerAnimating,
+      store.rightDrawerAnimating,
+    ]);
 
     const handleRightClick = () => {
       setScrollLeft((prev) => {


### PR DESCRIPTION
There is some strange interaction between the intersection observer and the drawers that sometimes causes all the cards to disappear. Removing this logic for now as the design has been fleshed out a bit better and we probably won't need this behaviour anymore