### PR TITLE
Format date locally in date pickers

### DIFF
--- a/components/ui/inputs.tsx
+++ b/components/ui/inputs.tsx
@@ -119,6 +119,25 @@ const getDateFromTimestamp = (timestamp?: number) => {
   return new Date(ts);
 };
 
+const getLocalDateFormat = () => {
+  const formatObj = new Intl.DateTimeFormat().formatToParts(new Date());
+
+  return formatObj
+    .map((obj) => {
+      switch (obj.type) {
+        case "day":
+          return "DD";
+        case "month":
+          return "MM";
+        case "year":
+          return "YYYY";
+        default:
+          return obj.value;
+      }
+    })
+    .join("");
+};
+
 export const DateTimeInput: FC<{
   timestamp?: number;
   className?: string;
@@ -137,6 +156,7 @@ export const DateTimeInput: FC<{
       onChange(v.valueOf());
     }
   };
+  const localDateFormat = getLocalDateFormat();
 
   return (
     <DateTime
@@ -144,7 +164,7 @@ export const DateTimeInput: FC<{
       renderInput={rdtpInput}
       inputProps={{ ref, className: `${invalid ? invalidClasses : ""}` }}
       onChange={dateChange}
-      dateFormat={true}
+      dateFormat={localDateFormat}
       className={className}
     />
   );


### PR DESCRIPTION
Seems like react-datetime isn't able to do this so using a bit a of hacky method to generate date format string by parsing a date generate by `Intl`

Should help with #414 