### PR TITLE
Add tests for scalar market winnings calculation

### DIFF
--- a/lib/util/calc-scalar-winnings.spec.ts
+++ b/lib/util/calc-scalar-winnings.spec.ts
@@ -1,0 +1,16 @@
+import { calcScalarWinnings } from "./calc-scalar-winnings";
+
+describe("calcScalarWinnings", () => {
+  test("should calculate winnings correct for short tokens", () => {
+    const winnings = calcScalarWinnings(0, 10, 5, 100, 0);
+    expect(winnings).toEqual(50);
+  });
+  test("should calculate winnings correct for long tokens", () => {
+    const winnings = calcScalarWinnings(0, 40, 10, 0, 100);
+    expect(winnings).toEqual(25);
+  });
+  test("should calculate winnings correct for both long and short tokens", () => {
+    const winnings = calcScalarWinnings(0, 40, 10, 100, 100);
+    expect(winnings).toEqual(100);
+  });
+});

--- a/lib/util/calc-scalar-winnings.spec.ts
+++ b/lib/util/calc-scalar-winnings.spec.ts
@@ -1,15 +1,15 @@
 import { calcScalarWinnings } from "./calc-scalar-winnings";
 
 describe("calcScalarWinnings", () => {
-  test("should calculate winnings correct for short tokens", () => {
+  test("should calculate winnings correctly for short tokens", () => {
     const winnings = calcScalarWinnings(0, 10, 5, 100, 0);
     expect(winnings).toEqual(50);
   });
-  test("should calculate winnings correct for long tokens", () => {
+  test("should calculate winnings correctly for long tokens", () => {
     const winnings = calcScalarWinnings(0, 40, 10, 0, 100);
     expect(winnings).toEqual(25);
   });
-  test("should calculate winnings correct for both long and short tokens", () => {
+  test("should calculate winnings correctly for both long and short tokens", () => {
     const winnings = calcScalarWinnings(0, 40, 10, 100, 100);
     expect(winnings).toEqual(100);
   });

--- a/lib/util/calc-scalar-winnings.spec.ts
+++ b/lib/util/calc-scalar-winnings.spec.ts
@@ -3,14 +3,14 @@ import { calcScalarWinnings } from "./calc-scalar-winnings";
 describe("calcScalarWinnings", () => {
   test("should calculate winnings correctly for short tokens", () => {
     const winnings = calcScalarWinnings(0, 10, 5, 100, 0);
-    expect(winnings).toEqual(50);
+    expect(winnings.toNumber()).toEqual(50);
   });
   test("should calculate winnings correctly for long tokens", () => {
     const winnings = calcScalarWinnings(0, 40, 10, 0, 100);
-    expect(winnings).toEqual(25);
+    expect(winnings.toNumber()).toEqual(25);
   });
   test("should calculate winnings correctly for both long and short tokens", () => {
     const winnings = calcScalarWinnings(0, 40, 10, 100, 100);
-    expect(winnings).toEqual(100);
+    expect(winnings.toNumber()).toEqual(100);
   });
 });

--- a/lib/util/calc-scalar-winnings.ts
+++ b/lib/util/calc-scalar-winnings.ts
@@ -1,16 +1,20 @@
-export const calcScalarWinnings = (
-  lowerBound: number,
-  upperBound: number,
-  resolvedNumber: number,
-  shortAssetAmount: number,
-  longAssetAmount: number,
-) => {
-  const priceRange = upperBound - lowerBound;
-  const resolvedNumberAsPercentage = (resolvedNumber - lowerBound) / priceRange;
-  const longTokenValue = resolvedNumberAsPercentage;
-  const shortTokenValue = 1 - resolvedNumberAsPercentage;
-  const longRewards = longAssetAmount * longTokenValue;
-  const shortRewards = shortAssetAmount * shortTokenValue;
+import Decimal from "decimal.js";
 
-  return longRewards + shortRewards;
+export const calcScalarWinnings = (
+  lowerBound: number | Decimal,
+  upperBound: number | Decimal,
+  resolvedNumber: number | Decimal,
+  shortAssetAmount: number | Decimal,
+  longAssetAmount: number | Decimal,
+) => {
+  const priceRange = new Decimal(upperBound).minus(lowerBound);
+  const resolvedNumberAsPercentage = new Decimal(resolvedNumber)
+    .minus(lowerBound)
+    .div(priceRange);
+  const longTokenValue = resolvedNumberAsPercentage;
+  const shortTokenValue = new Decimal(1).minus(resolvedNumberAsPercentage);
+  const longRewards = new Decimal(longAssetAmount).mul(longTokenValue);
+  const shortRewards = new Decimal(shortAssetAmount).mul(shortTokenValue);
+
+  return new Decimal(longRewards).plus(shortRewards);
 };

--- a/lib/util/calc-scalar-winnings.ts
+++ b/lib/util/calc-scalar-winnings.ts
@@ -1,0 +1,16 @@
+export const calcScalarWinnings = (
+  lowerBound: number,
+  upperBound: number,
+  resolvedNumber: number,
+  shortAssetAmount: number,
+  longAssetAmount: number,
+) => {
+  const priceRange = upperBound - lowerBound;
+  const resolvedNumberAsPercentage = (resolvedNumber - lowerBound) / priceRange;
+  const longTokenValue = resolvedNumberAsPercentage;
+  const shortTokenValue = 1 - resolvedNumberAsPercentage;
+  const longRewards = longAssetAmount * longTokenValue;
+  const shortRewards = shortAssetAmount * shortTokenValue;
+
+  return longRewards + shortRewards;
+};


### PR DESCRIPTION
Should help us rule out calculation errors from being the source of scalar redemption amount bugs