### PR TITLE
Refactor market page asset fetching

### DIFF
--- a/lib/hooks/queries/useAccountPoolAssetBalances.ts
+++ b/lib/hooks/queries/useAccountPoolAssetBalances.ts
@@ -1,12 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
-import {
-  Context,
-  isIndexedData,
-  isRpcData,
-  isRpcSdk,
-  Pool,
-} from "@zeitgeistpm/sdk-next";
-import { KeyringPairOrExtSigner } from "@zeitgeistpm/sdk/dist/types";
+import { Context, isIndexedData, isRpcSdk, Pool } from "@zeitgeistpm/sdk-next";
+import { getApiAtBlock } from "lib/util/get-api-at";
 import { useSdkv2 } from "../useSdkv2";
 
 export const rootKey = "account-pool-asset-balances";
@@ -14,6 +8,7 @@ export const rootKey = "account-pool-asset-balances";
 export const useAccountPoolAssetBalances = (
   address?: string,
   pool?: Pool<Context>,
+  blockNumber?: number,
 ) => {
   const [sdk, id] = useSdkv2();
 
@@ -27,7 +22,9 @@ export const useAccountPoolAssetBalances = (
               .map((weight) => JSON.parse(weight.assetId))
           : pool.assets;
 
-        const balances = await sdk.context.api.query.tokens.accounts.multi(
+        const api = await getApiAtBlock(sdk.context.api, blockNumber);
+
+        const balances = await api.query.tokens.accounts.multi(
           assets.map((assets) => [address, assets]),
         );
 

--- a/lib/hooks/queries/useAccountPoolAssetBalances.ts
+++ b/lib/hooks/queries/useAccountPoolAssetBalances.ts
@@ -13,7 +13,7 @@ export const useAccountPoolAssetBalances = (
   const [sdk, id] = useSdkv2();
 
   const query = useQuery(
-    [id, rootKey, address, pool?.poolId],
+    [id, rootKey, address, pool?.poolId, blockNumber],
     async () => {
       if (isRpcSdk(sdk)) {
         const assets = isIndexedData(pool)

--- a/lib/hooks/queries/useMarket24hrPriceChanges.ts
+++ b/lib/hooks/queries/useMarket24hrPriceChanges.ts
@@ -54,6 +54,8 @@ export const useMarket24hrPriceChanges = (marketId: number) => {
             const priceDiff = nowPrice.minus(pastPrice);
             const priceChange = priceDiff.div(pastPrice);
             priceChanges.set(key, Math.round(priceChange.mul(100).toNumber()));
+          } else {
+            priceChanges.set(key, 0);
           }
         }
 

--- a/lib/hooks/queries/useMarket24hrPriceChanges.ts
+++ b/lib/hooks/queries/useMarket24hrPriceChanges.ts
@@ -1,0 +1,65 @@
+import { useQuery } from "@tanstack/react-query";
+import { isRpcSdk } from "@zeitgeistpm/sdk-next";
+import { useStore } from "lib/stores/Store";
+import { useSdkv2 } from "../useSdkv2";
+import { useMarketSpotPrices } from "./useMarketSpotPrices";
+
+export const market24hrPriceChangesKey = Symbol();
+
+const getBlock24hrsAgo = (blockTimeSec: number, currentBlock: number) => {
+  const daySeconds = 24 * 60 * 60;
+  const dayBlocks = daySeconds / blockTimeSec;
+  console.log(dayBlocks);
+
+  return currentBlock - dayBlocks;
+};
+
+export const useMarket24hrPriceChanges = (marketId: number) => {
+  const [sdk, id] = useSdkv2();
+
+  //todo: prevent block number change updates
+  const { config, blockNumber } = useStore();
+
+  const block24hrsAgo =
+    config?.blockTimeSec && blockNumber
+      ? getBlock24hrsAgo(config.blockTimeSec, blockNumber.toNumber())
+      : null;
+
+  const { data: pricesNow } = useMarketSpotPrices(marketId);
+  const { data: prices24hrsAgo } = useMarketSpotPrices(marketId, block24hrsAgo);
+
+  const query = useQuery(
+    [id, market24hrPriceChangesKey],
+    async () => {
+      if (isRpcSdk(sdk)) {
+        console.log("recalc");
+
+        const priceChanges = new Map<number, number>();
+
+        for (const [key, nowPrice] of pricesNow.entries()) {
+          const pastPrice = prices24hrsAgo.get(key);
+
+          if (pastPrice != null && nowPrice != null) {
+            const priceDiff = nowPrice.minus(pastPrice);
+            const priceChange = priceDiff.div(pastPrice);
+            priceChanges.set(key, Math.round(priceChange.mul(100).toNumber()));
+          }
+        }
+
+        return priceChanges;
+      }
+    },
+    {
+      enabled: Boolean(
+        sdk &&
+          isRpcSdk(sdk) &&
+          marketId != null &&
+          block24hrsAgo &&
+          pricesNow &&
+          prices24hrsAgo,
+      ),
+    },
+  );
+
+  return query;
+};

--- a/lib/hooks/queries/useMarket24hrPriceChanges.ts
+++ b/lib/hooks/queries/useMarket24hrPriceChanges.ts
@@ -43,8 +43,6 @@ export const useMarket24hrPriceChanges = (marketId: number) => {
     [id, market24hrPriceChangesKey],
     async () => {
       if (isRpcSdk(sdk)) {
-        console.log("recalc");
-
         const priceChanges = new Map<number, number>();
 
         for (const [key, nowPrice] of pricesNow.entries()) {

--- a/lib/hooks/queries/useMarketSpotPrices.ts
+++ b/lib/hooks/queries/useMarketSpotPrices.ts
@@ -37,7 +37,6 @@ export const useMarketSpotPrices = (marketId: number, blockNumber?: number) => {
           //base weight is equal to the sum of all other assets
           const baseWeight = new Decimal(pool.totalWeight).div(2);
 
-          //todo: check with fresh market, balances could be null
           outcomeWeights.forEach((weight, index) => {
             const spotPrice = calcSpotPrice(
               basePoolBalance.toString(),
@@ -47,7 +46,7 @@ export const useMarketSpotPrices = (marketId: number, blockNumber?: number) => {
               0,
             );
 
-            spotPrices.set(index, spotPrice);
+            spotPrices.set(index, spotPrice.isNaN() ? null : spotPrice);
           });
           return spotPrices;
         } else {

--- a/lib/hooks/queries/useZtgBalance.ts
+++ b/lib/hooks/queries/useZtgBalance.ts
@@ -1,21 +1,21 @@
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
-import { isRpcData, isRpcSdk, NA, PoolGetQuery } from "@zeitgeistpm/sdk-next";
-import { KeyringPairOrExtSigner } from "@zeitgeistpm/sdk/dist/types";
+import { useQuery } from "@tanstack/react-query";
+import { isRpcSdk, NA } from "@zeitgeistpm/sdk-next";
 import Decimal from "decimal.js";
+import { getApiAtBlock } from "lib/util/get-api-at";
 import { useSdkv2 } from "../useSdkv2";
 
 export const rootKey = "ztg-balance";
 
-export const useZtgBalance = (account?: KeyringPairOrExtSigner) => {
+export const useZtgBalance = (address: string, blockNumber?: number) => {
   const [sdk, id] = useSdkv2();
 
   const query = useQuery(
-    [id, rootKey, account?.address],
+    [id, rootKey, address],
     async () => {
-      if (account && isRpcSdk(sdk)) {
-        const balance = await sdk.context.api.query.system.account(
-          account.address,
-        );
+      if (address && isRpcSdk(sdk)) {
+        const api = await getApiAtBlock(sdk.context.api, blockNumber);
+
+        const balance = await api.query.system.account(address);
         return new Decimal(balance.data.free.toString());
       }
       return NA;
@@ -23,7 +23,7 @@ export const useZtgBalance = (account?: KeyringPairOrExtSigner) => {
     {
       initialData: NA,
       keepPreviousData: true,
-      enabled: Boolean(sdk && account && isRpcSdk(sdk)),
+      enabled: Boolean(sdk && address && isRpcSdk(sdk)),
     },
   );
 

--- a/lib/hooks/queries/useZtgBalance.ts
+++ b/lib/hooks/queries/useZtgBalance.ts
@@ -10,7 +10,7 @@ export const useZtgBalance = (address: string, blockNumber?: number) => {
   const [sdk, id] = useSdkv2();
 
   const query = useQuery(
-    [id, rootKey, address],
+    [id, rootKey, address, blockNumber],
     async () => {
       if (address && isRpcSdk(sdk)) {
         const api = await getApiAtBlock(sdk.context.api, blockNumber);

--- a/lib/state/tradeslip/tradeslipItemsState.ts
+++ b/lib/state/tradeslip/tradeslipItemsState.ts
@@ -149,7 +149,7 @@ export const useTradeslipItemsState = (
 
   const [slippage] = useAtom(slippagePercentageAtom);
 
-  const { data: traderZtgBalance } = useZtgBalance(signer);
+  const { data: traderZtgBalance } = useZtgBalance(signer?.address);
 
   const { data: pools } = usePoolsByIds(
     items.map((item) => ({ marketId: getMarketIdOf(item.assetId) })),

--- a/lib/stores/Store.ts
+++ b/lib/stores/Store.ts
@@ -176,6 +176,7 @@ export default class Store {
     this.initGraphQlClient();
 
     this.userStore.checkIP();
+    this.fetchZTGPrice();
     try {
       await this.initSDK(this.userStore.endpoint, this.userStore.gqlEndpoint);
       await this.loadConfig();
@@ -200,8 +201,6 @@ export default class Store {
       );
       this.initialize();
     }
-
-    this.fetchZTGPrice();
   }
 
   async connectNewSDK(endpoint: string, gqlEndpoint: string) {

--- a/lib/util/get-api-at.ts
+++ b/lib/util/get-api-at.ts
@@ -1,0 +1,14 @@
+import type { ApiPromise } from "@polkadot/api";
+
+export const getApiAtBlock = async (
+  api: ApiPromise,
+  blockNumber?: number,
+): Promise<ApiPromise> => {
+  if (blockNumber != null) {
+    const blockHash = await api.rpc.chain.getBlockHash(blockNumber);
+    const apiAt = (await api.at(blockHash)) as ApiPromise;
+    return apiAt;
+  } else {
+    return api;
+  }
+};

--- a/lib/wallets/index.ts
+++ b/lib/wallets/index.ts
@@ -236,7 +236,7 @@ export default class Wallets {
 
     const signer = this.wallet.signer;
 
-    return { address: this.activeAccount.address, signer: signer };
+    return { address: this.activeAccount?.address, signer: signer };
   }
 
   get testingKeyringPair(): KeyringPair | undefined {

--- a/pages/markets/[marketid].tsx
+++ b/pages/markets/[marketid].tsx
@@ -119,7 +119,6 @@ const Market: NextPage<{
   const store = useStore();
   const [pool, setPool] = useState<CPool>();
   const poolStore = usePoolsStore();
-  const [hasAuthReport, setHasAuthReport] = useState<boolean>();
   const marketImageUrl = useMarketImageUrl(indexedMarket.img);
 
   const { data: marketSdkv2, isLoading: marketIsLoading } = useMarket(
@@ -146,13 +145,6 @@ const Market: NextPage<{
 
         setPool(pool);
       }
-
-      const report =
-        await store.sdk.api.query.authorized.authorizedOutcomeReports(
-          market.id,
-        );
-
-      setHasAuthReport(report.isEmpty === false);
     }
   };
 

--- a/pages/markets/[marketid].tsx
+++ b/pages/markets/[marketid].tsx
@@ -1,4 +1,3 @@
-import { ScalarRangeType } from "@zeitgeistpm/sdk/dist/types";
 import LiquidityPill from "components/markets/LiquidityPill";
 import MarketAddresses from "components/markets/MarketAddresses";
 import MarketAssetDetails from "components/markets/MarketAssetDetails";
@@ -38,7 +37,6 @@ import { useRouter } from "next/router";
 import NotFoundPage from "pages/404";
 import { useEffect, useState } from "react";
 import { AlertTriangle } from "react-feather";
-import { combineLatest, from } from "rxjs";
 const QuillViewer = dynamic(() => import("../../components/ui/QuillViewer"), {
   ssr: false,
 });
@@ -226,7 +224,6 @@ const Market: NextPage<{
         ) : (
           <></>
         )}
-        {/* todo: test */}
         {marketSdkv2?.pool?.poolId == null && marketIsLoading === false && (
           <div className="flex h-ztg-22 items-center  bg-vermilion-light text-vermilion p-ztg-20 rounded-ztg-5">
             <div className="w-ztg-20 h-ztg-20">

--- a/pages/markets/[marketid].tsx
+++ b/pages/markets/[marketid].tsx
@@ -122,7 +122,9 @@ const Market: NextPage<{
   const [hasAuthReport, setHasAuthReport] = useState<boolean>();
   const marketImageUrl = useMarketImageUrl(indexedMarket.img);
 
-  const { data: marketSdkv2 } = useMarket(Number(marketid));
+  const { data: marketSdkv2, isLoading: marketIsLoading } = useMarket(
+    Number(marketid),
+  );
   const { data: marketStage } = useMarketStage(marketSdkv2);
 
   const { data: spotPrices } = useMarketSpotPrices(Number(marketid));
@@ -232,7 +234,8 @@ const Market: NextPage<{
         ) : (
           <></>
         )}
-        {marketStore?.poolExists === false && (
+        {/* todo: test */}
+        {marketSdkv2?.pool?.poolId == null && marketIsLoading === false && (
           <div className="flex h-ztg-22 items-center  bg-vermilion-light text-vermilion p-ztg-20 rounded-ztg-5">
             <div className="w-ztg-20 h-ztg-20">
               <AlertTriangle size={20} />
@@ -246,7 +249,10 @@ const Market: NextPage<{
             </div>
           </div>
         )}
-        {marketStore && <MarketAssetDetails marketStore={marketStore} />}
+        <MarketAssetDetails
+          marketId={Number(marketid)}
+          marketStore={marketStore}
+        />
         {marketStore?.type === "scalar" && spotPrices && (
           <div className="mt-ztg-20 mb-ztg-30">
             <ScalarPriceRange


### PR DESCRIPTION
- Begin rendering before before `MarketStore` is initialised
- Use Graphql data to display asset details earlier
- Load prices and 24hr change async 
- Use more efficient method of fetching 24hr change
