### PR TITLE
Recalculate prices when basePoolBalance or balances change

### DIFF
--- a/lib/hooks/queries/useMarketSpotPrices.ts
+++ b/lib/hooks/queries/useMarketSpotPrices.ts
@@ -27,7 +27,7 @@ export const useMarketSpotPrices = (marketId: number, blockNumber?: number) => {
   const { data: basePoolBalance } = useZtgBalance(pool?.accountId, blockNumber);
 
   const query = useQuery(
-    [id, marketSpotPricesKey, pool, blockNumber],
+    [id, marketSpotPricesKey, pool, blockNumber, balances, basePoolBalance],
     async () => {
       if (isRpcSdk(sdk) && !isNA(basePoolBalance)) {
         const spotPrices: MarketPrices =


### PR DESCRIPTION
Previously prices weren't being recalculated when the underlying queries were invalidated