### PR TITLE
quickfix inability to create scalar date markets

### DIFF
--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -472,14 +472,18 @@ const CreatePage: NextPage = observer(() => {
         }
       : {
           Scalar: [
-            new Decimal(outcomes.minimum)
-              .mul(ZTG)
-              .toDecimalPlaces(0)
-              .toNumber(),
-            new Decimal(outcomes.maximum)
-              .mul(ZTG)
-              .toDecimalPlaces(0)
-              .toNumber(),
+            BigInt(
+              new Decimal(outcomes.minimum)
+                .mul(ZTG)
+                .toDecimalPlaces(0)
+                .toFixed(0),
+            ) as any,
+            BigInt(
+              new Decimal(outcomes.maximum)
+                .mul(ZTG)
+                .toDecimalPlaces(0)
+                .toFixed(0),
+            ) as any,
           ],
         };
   };


### PR DESCRIPTION
This is a quickfix so creation of scalar date markets work, but this needs to be done on sdk so `marketType` has correcnt type for `Scalar`

https://github.com/zeitgeistpm/tools/issues/246
