### PR TITLE
Update README.md with environment variables setup step before running server

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@
 
 `yarn install`
 
+## Setup environment variables
+
+Some features require environment variables. To test locally create `.env.local` file from `.env.example`.
+
+`cp .env.example .env.local`
+
 ## Run development environment
 
 `yarn dev`
-
-## Environment variables
-
-Some features require environment variables. To test locally create `.env.local` file from `.env.example`.


### PR DESCRIPTION
as a new zeitgeist user that wanted to run the ui locally, i copied the commands to run the server but overlooked setting up the environment variables https://github.com/zeitgeistpm/ui/issues/686, so since setting up the environment variables is required for most users that would follow the readme, i think that step should be shown before the step where you run the server, and showing the command itself instead of just the description