### PR TITLE
Add chart tool tip colour coding

### DIFF
--- a/components/menu/MenuLogo.tsx
+++ b/components/menu/MenuLogo.tsx
@@ -3,11 +3,12 @@ import Link from "next/link";
 import Logo from "../icons/ZeitgeistIcon";
 import { useStore } from "lib/stores/Store";
 import { useRouter } from "next/router";
+import { observer } from "mobx-react";
 
 const MenuLogo: FC<{
   menuOpen: boolean;
   setMenuOpen?: (boolean) => void;
-}> = ({ menuOpen, setMenuOpen }) => {
+}> = observer(({ menuOpen, setMenuOpen }) => {
   const { pathname } = useRouter();
   const { blockNumber } = useStore();
 
@@ -39,6 +40,6 @@ const MenuLogo: FC<{
       </>
     </Link>
   );
-};
+});
 
 export default MenuLogo;

--- a/components/ui/TimeSeriesChart.tsx
+++ b/components/ui/TimeSeriesChart.tsx
@@ -57,13 +57,19 @@ const ChartToolTip = observer((props) => {
             <div className="mt-ztg-13">
               {props.series?.map((asset, index) => (
                 <div key={index} className="flex flex-col mt-1">
-                  <span className="font-semibold capitalize">
-                    {asset.label}
-                  </span>
-                  <span className="">
+                  <div className="flex items-center">
+                    <div
+                      className="bg-black w-[8px] h-[8px] rounded-full"
+                      style={{ backgroundColor: asset.color }}
+                    ></div>
+                    <div className="font-semibold capitalize ml-[6px]">
+                      {asset.label}
+                    </div>
+                  </div>
+                  <div>
                     {new Decimal(props.payload[index]?.value ?? 0).toFixed(3) +
                       ` ${props.yUnits}`}
-                  </span>
+                  </div>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
Currently not possible to tell which outcome corresponds to which line on the chart.

Looks like this now:
<img width="927" alt="image" src="https://user-images.githubusercontent.com/4950844/225576131-58332097-574a-46f7-a4e7-d1a4fbf79416.png">
