### PR TITLE
Fix market list shuffle

### DIFF
--- a/components/markets/MarketsList.tsx
+++ b/components/markets/MarketsList.tsx
@@ -1,4 +1,4 @@
-import { Context, IndexedMarket, ScalarRangeType } from "@zeitgeistpm/sdk-next";
+import { ScalarRangeType } from "@zeitgeistpm/sdk-next";
 import React, { useEffect, useState } from "react";
 import Decimal from "decimal.js";
 import { useInView } from "react-intersection-observer";
@@ -7,7 +7,6 @@ import Loader from "react-spinners/PulseLoader";
 import { X } from "react-feather";
 import { useRouter } from "next/router";
 import { useInfiniteMarkets } from "lib/hooks/queries/useInfiniteMarkets";
-import { MarketOutcomes } from "lib/types/markets";
 import { MarketFilter, MarketsOrderBy } from "lib/types/market-filter";
 import MarketFilterSelection from "./market-filter";
 import MarketCard from "./market-card/index";
@@ -79,18 +78,7 @@ const MarketsList = observer(({ className = "" }: MarketsListProps) => {
     }
   }, [isLoadMarkerInView, hasNextPage]);
 
-  const [markets, setMarkets] = useState<
-    (IndexedMarket<Context> & {
-      outcomes: MarketOutcomes;
-      prediction: { name: string; price: number };
-    })[]
-  >();
-
-  useEffect(() => {
-    const markets =
-      marketsPages?.pages.flatMap((markets) => markets.data) ?? [];
-    setMarkets(markets);
-  }, [marketsPages?.pages]);
+  const markets = marketsPages?.pages.flatMap((markets) => markets.data) ?? [];
 
   const count = markets?.length ?? 0;
   const marketIds = markets?.map((m) => m.marketId) ?? [];

--- a/components/markets/market-filter/index.tsx
+++ b/components/markets/market-filter/index.tsx
@@ -186,7 +186,7 @@ const MarketFilterSelection = ({
 }) => {
   const [activeFilters, setActiveFilters] = useState<MarketFilter[]>();
   const [activeOrdering, setActiveOrdering] = useState<MarketsOrderBy>();
-  const [withLiquidityOnly, setWithLiquidityOnly] = useState<boolean>(false);
+  const [withLiquidityOnly, setWithLiquidityOnly] = useState<boolean>();
   const portalRef = useRef<HTMLDivElement>(null);
 
   const queryState = useMarketsUrlQuery();

--- a/lib/hooks/queries/useInfiniteMarkets.ts
+++ b/lib/hooks/queries/useInfiniteMarkets.ts
@@ -68,7 +68,12 @@ export const useInfiniteMarkets = (
   const fetcher = async ({
     pageParam = 0,
   }): Promise<{ data: QueryMarketData[]; next: number | boolean }> => {
-    if (!isIndexedSdk(sdk) || filters == null) {
+    if (
+      !isIndexedSdk(sdk) ||
+      filters == null ||
+      orderBy == null ||
+      withLiquidityOnly == null
+    ) {
       return {
         data: [],
         next: false,
@@ -126,9 +131,13 @@ export const useInfiniteMarkets = (
   const query = useInfiniteQuery({
     queryKey: [id, rootKey, hashFilters(filters), orderBy, withLiquidityOnly],
     queryFn: fetcher,
-    enabled: Boolean(sdk) && isIndexedSdk(sdk),
+    enabled:
+      Boolean(sdk) &&
+      isIndexedSdk(sdk) &&
+      filters !== undefined &&
+      orderBy !== undefined &&
+      withLiquidityOnly !== undefined,
     getNextPageParam: (lastPage) => lastPage.next,
-    keepPreviousData: true,
     onSuccess(data) {
       data.pages
         .flatMap((p) => p.data)


### PR DESCRIPTION
Remove useEffect that is potentially preventing to rerender on prod
Don't fetch data if filters aren't loaded