### PR TITLE
Fix: update resolution date query

### DIFF
--- a/lib/gql/resolution-date.ts
+++ b/lib/gql/resolution-date.ts
@@ -3,7 +3,7 @@ import { gql, GraphQLClient } from "graphql-request";
 const resolutionQuery = gql`
   query MarketResolutionDate($marketId: Int) {
     historicalMarkets(
-      where: { event_contains: "Resolved", marketId_eq: $marketId }
+      where: { event_eq: MarketResolved, marketId_eq: $marketId }
     ) {
       timestamp
     }


### PR DESCRIPTION
resolves `Field "event_contains" is not defined by type "HistoricalMarketWhereInput". Did you mean "event_not_in", "id_not_contains", "id_contains", "event_in", or "event_not_eq"?:`