### PR TITLE
Replace min liquidity with hardcoded amount

### DIFF
--- a/components/liquidity/PoolSettings.tsx
+++ b/components/liquidity/PoolSettings.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent, FC, MouseEvent } from "react";
 import { MultipleOutcomeEntry } from "lib/types/create-market";
 import Table, { TableColumn, TableData } from "components/ui/Table";
-import { ZTG, ZTG_BLUE_COLOR } from "lib/constants";
+import { ZTG, ZTG_BLUE_COLOR, ZTG_MIN_LIQUIDITY } from "lib/constants";
 import { motion } from "framer-motion";
 import PoolFeesSelect from "./PoolFeesSelect";
 import Decimal from "decimal.js";
@@ -190,7 +190,7 @@ const PoolSettings: FC<{
       },
       amount: {
         value: d.amount,
-        min: constants?.swaps.minLiquidity.toString(),
+        min: ZTG_MIN_LIQUIDITY.toString(),
         onChange: (amount: string) => {
           changeOutcomeRow(amount);
         },

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -1,5 +1,4 @@
 import Decimal from "decimal.js";
-import { GraphQLClient } from "graphql-request";
 import resolveTailwindConfig from "tailwindcss/resolveConfig";
 import tailwindConfig from "../../tailwind.config";
 import { EndpointOption, Environment } from "../types";
@@ -16,6 +15,7 @@ export const BLOCK_TIME_SECONDS = Number(
 export const NUM_BLOCKS_IN_HOUR = 3600 / BLOCK_TIME_SECONDS;
 export const NUM_BLOCKS_IN_DAY = NUM_BLOCKS_IN_HOUR * 24;
 export const DAY_SECONDS = 86400;
+export const ZTG_MIN_LIQUIDITY = 100;
 
 export const ZTG_BLUE_COLOR = resolveTailwindConfig(tailwindConfig as any).theme
   .colors["ztg-blue"];

--- a/lib/hooks/queries/useChainConstants.ts
+++ b/lib/hooks/queries/useChainConstants.ts
@@ -22,7 +22,6 @@ export type ChainConstants = {
     stakeWeight: number; // increase in juror stake per juror
   };
   swaps: {
-    minLiquidity: number;
     exitFee: number;
   };
   identity: {
@@ -75,7 +74,6 @@ export const useChainConstants = () => {
           stakeWeight: consts.court.stakeWeight.toNumber() / ZTG,
         },
         swaps: {
-          minLiquidity: consts.swaps.minLiquidity.toNumber() / ZTG,
           exitFee: consts.swaps.exitFee.toNumber() / ZTG,
         },
         identity: {


### PR DESCRIPTION
The min liquidity parameter is being removed from the runtime so we need to remove references to it. We agreed that a reasonable limitation should be added to the front end 