### PR TITLE
Add back scalar bounds to market page

### DIFF
--- a/components/markets/MarketHeader.tsx
+++ b/components/markets/MarketHeader.tsx
@@ -25,6 +25,7 @@ import Modal from "components/ui/Modal";
 import { getMarketStatusDetails } from "lib/util/market-status-details";
 import { getScalarOutcome } from "lib/util/get-scalar-outcome";
 import { Dialog } from "@headlessui/react";
+import { usePoolLiquidity } from "lib/hooks/queries/usePoolLiquidity";
 
 const UserIdentity: FC<
   PropsWithChildren<{ user: string; className?: string }>
@@ -272,7 +273,6 @@ const MarketHeader: FC<{
   disputes: MarketDispute;
   resolvedOutcome: string;
   prizePool: number;
-  subsidy: number;
   token: string;
   marketStage: MarketStage;
   rejectReason?: string;
@@ -282,7 +282,6 @@ const MarketHeader: FC<{
   disputes,
   resolvedOutcome,
   prizePool,
-  subsidy,
   token,
   marketStage,
   rejectReason,
@@ -317,6 +316,9 @@ const MarketHeader: FC<{
   const { data: marketHistory } = useMarketEventHistory(
     market.marketId.toString(),
   );
+  const { data: liquidity, isLoading: isLiqudityLoading } = usePoolLiquidity({
+    marketId: market.marketId,
+  });
 
   return (
     <header className="flex flex-col items-center w-full max-w-[1000px] mx-auto">
@@ -372,9 +374,9 @@ const MarketHeader: FC<{
         ) : (
           <Skeleton width="150px" height="20px" />
         )}
-        {subsidy >= 0 && token ? (
-          <HeaderStat label="Subsidy" border={false}>
-            {formatNumberCompact(subsidy)}
+        {isLiqudityLoading === false && token ? (
+          <HeaderStat label="Liquidity" border={false}>
+            {formatNumberCompact(liquidity.div(ZTG).toNumber())}
             &nbsp;
             {token}
           </HeaderStat>

--- a/lib/hooks/queries/usePoolLiquidity.ts
+++ b/lib/hooks/queries/usePoolLiquidity.ts
@@ -1,7 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
+import { parseAssetId } from "@zeitgeistpm/sdk-next";
 import Decimal from "decimal.js";
 import { useSdkv2 } from "../useSdkv2";
 import { useAccountPoolAssetBalances } from "./useAccountPoolAssetBalances";
+import { useBalance } from "./useBalance";
 import { useMarket, UseMarketFilter } from "./useMarket";
 import { useMarketSpotPrices } from "./useMarketSpotPrices";
 
@@ -18,16 +20,26 @@ export const usePoolLiquidity = (filter?: UseMarketFilter) => {
     market?.pool,
   );
 
+  const baseAssetId = parseAssetId(market?.baseAsset).unrightOr(null);
+  const { data: baseAssetBalance } = useBalance(
+    market?.pool?.accountId,
+    baseAssetId,
+  );
+
   const query = useQuery(
-    [id, poolsLiqudityRootKey, filter, spotPrices, balances],
+    [id, poolsLiqudityRootKey, filter, spotPrices, balances, baseAssetBalance],
     async () => {
-      return balances.reduce((totalLiquidty, balance, index) => {
-        const spotPrice = spotPrices.get(index) ?? new Decimal(1);
-        return totalLiquidty.plus(spotPrice.mul(balance.free.toString()));
-      }, new Decimal(0));
+      return balances
+        .reduce((totalLiquidty, balance, index) => {
+          const spotPrice = spotPrices.get(index) ?? new Decimal(1);
+          return totalLiquidty.plus(spotPrice.mul(balance.free.toString()));
+        }, new Decimal(0))
+        .add(baseAssetBalance);
     },
     {
-      enabled: Boolean(sdk && market && spotPrices && balances),
+      enabled: Boolean(
+        sdk && market && spotPrices && balances && baseAssetBalance,
+      ),
     },
   );
 

--- a/pages/markets/[marketid].tsx
+++ b/pages/markets/[marketid].tsx
@@ -168,9 +168,6 @@ const Market: NextPage<MarketPageProps> = ({
   //data for MarketHeader
   const token = metadata?.symbol;
 
-  const subsidy =
-    marketSdkv2?.pool?.poolId == null ? 0 : liquidity?.div(ZTG).toNumber();
-
   return (
     <>
       <MarketMeta market={indexedMarket} />
@@ -199,7 +196,6 @@ const Market: NextPage<MarketPageProps> = ({
           disputes={lastDispute}
           token={token}
           prizePool={prizePool?.div(ZTG).toNumber()}
-          subsidy={subsidy}
           marketStage={marketStage}
           rejectReason={marketSdkv2?.rejectReason}
         />

--- a/pages/markets/[marketid].tsx
+++ b/pages/markets/[marketid].tsx
@@ -8,9 +8,12 @@ import MarketChart from "components/markets/MarketChart";
 import MarketHeader from "components/markets/MarketHeader";
 import PoolDeployer from "components/markets/PoolDeployer";
 import { MarketPromotionCallout } from "components/markets/PromotionCallout";
+import ScalarPriceRange from "components/markets/ScalarPriceRange";
 import MarketMeta from "components/meta/MarketMeta";
 import MarketImage from "components/ui/MarketImage";
+import Skeleton from "components/ui/Skeleton";
 import { ChartSeries } from "components/ui/TimeSeriesChart";
+import Decimal from "decimal.js";
 import { GraphQLClient } from "graphql-request";
 import {
   PromotedMarket,
@@ -232,9 +235,30 @@ const Market: NextPage<MarketPageProps> = ({
             </div>
           </div>
         )}
-
         <div className="mb-8">
           <h3 className="text-center text-2xl mt-10 mb-8">Predictions</h3>
+          {indexedMarket?.marketType?.scalar !== null && (
+            <div className="mb-8 max-w-[800px] mx-auto">
+              {marketIsLoading ||
+              (!spotPrices?.get(1) && indexedMarket.status !== "Proposed") ||
+              (!spotPrices?.get(0) && indexedMarket.status !== "Proposed") ? (
+                <Skeleton height="40px" width="100%" />
+              ) : (
+                <ScalarPriceRange
+                  scalarType={indexedMarket.scalarType}
+                  lowerBound={new Decimal(indexedMarket.marketType.scalar[0])
+                    .div(ZTG)
+                    .toNumber()}
+                  upperBound={new Decimal(indexedMarket.marketType.scalar[1])
+                    .div(ZTG)
+                    .toNumber()}
+                  shortPrice={spotPrices?.get(1).toNumber()}
+                  longPrice={spotPrices?.get(0).toNumber()}
+                  status={indexedMarket.status}
+                />
+              )}
+            </div>
+          )}
           <MarketAssetDetails marketId={Number(marketid)} />
         </div>
 


### PR DESCRIPTION
Add back scalar bounds. 
Include base asset with useLiquidity and Fix loading state

closes #1252 
closes #1197 

