### PR TITLE
Consolidate components to use useExtrinsic

### DIFF
--- a/components/assets/AssetActionButtons/RedeemButton.tsx
+++ b/components/assets/AssetActionButtons/RedeemButton.tsx
@@ -9,7 +9,6 @@ import {
   MarketId,
   parseAssetId,
 } from "@zeitgeistpm/sdk-next";
-import * as AE from "@zeitgeistpm/utility/dist/aeither";
 import SecondaryButton from "components/ui/SecondaryButton";
 import Decimal from "decimal.js";
 import { ZTG } from "lib/constants";
@@ -17,13 +16,13 @@ import {
   AccountAssetIdPair,
   useAccountAssetBalances,
 } from "lib/hooks/queries/useAccountAssetBalances";
+import { useExtrinsic } from "lib/hooks/useExtrinsic";
 import { useSdkv2 } from "lib/hooks/useSdkv2";
 import { useNotifications } from "lib/state/notifications";
 import { useWallet } from "lib/state/wallet";
 import { calcScalarWinnings } from "lib/util/calc-scalar-winnings";
-import { extrinsicCallback, signAndSend } from "lib/util/tx";
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 
 export type RedeemButtonProps = {
   market: Market<IndexerContext>;
@@ -126,47 +125,30 @@ const RedeemButtonByValue = ({
   const signer = wallet?.getActiveSigner();
   const notificationStore = useNotifications();
 
-  const [isRedeeming, setIsRedeeming] = useState(false);
-  const [isRedeemed, setIsRedeemed] = useState(false);
-
-  const handleClick = async () => {
-    if (!isRpcSdk(sdk) || !signer) return;
-
-    setIsRedeeming(true);
-
-    const callback = extrinsicCallback({
-      api: sdk.api,
-      notifications: notificationStore,
-      successCallback: async () => {
+  const { isLoading, isSuccess, send } = useExtrinsic(
+    () => {
+      if (!isRpcSdk(sdk) || !signer) return;
+      return sdk.api.tx.predictionMarkets.redeemShares(market.marketId);
+    },
+    {
+      onSuccess: () => {
         notificationStore.pushNotification(`Redeemed ${value.toFixed(2)} ZTG`, {
           type: "Success",
         });
-        setIsRedeeming(false);
-        setIsRedeemed(true);
       },
-      failCallback: (error) => {
-        notificationStore.pushNotification(error, {
-          type: "Error",
-        });
-        setIsRedeeming(false);
-      },
-    });
+    },
+  );
 
-    const tx = sdk.api.tx.predictionMarkets.redeemShares(market.marketId);
-
-    await AE.from(() => signAndSend(tx, signer, callback));
-
-    setIsRedeeming(false);
-  };
+  const handleClick = () => send();
 
   return (
     <>
-      {isRedeemed ? (
+      {isSuccess ? (
         <span className="text-green-500 font-bold">Redeemed Tokens!</span>
       ) : (
         <SecondaryButton
           onClick={handleClick}
-          disabled={isRedeeming || value.eq(0)}
+          disabled={isLoading || value.eq(0)}
         >
           Redeem Tokens
         </SecondaryButton>

--- a/components/outcomes/ScalarReportBox.tsx
+++ b/components/outcomes/ScalarReportBox.tsx
@@ -8,10 +8,10 @@ import { DateTimeInput } from "components/ui/inputs";
 import TransactionButton from "components/ui/TransactionButton";
 import Decimal from "decimal.js";
 import { ZTG } from "lib/constants";
+import { useExtrinsic } from "lib/hooks/useExtrinsic";
 import { useSdkv2 } from "lib/hooks/useSdkv2";
 import { useNotifications } from "lib/state/notifications";
 import { useWallet } from "lib/state/wallet";
-import { extrinsicCallback, signAndSend } from "lib/util/tx";
 import { useState } from "react";
 
 const ScalarReportBox = ({
@@ -39,40 +39,40 @@ const ScalarReportBox = ({
     return ((bounds[1].toNumber() + bounds[0].toNumber()) / 2).toFixed(0);
   });
 
-  const reportDisabled = !sdk || !isRpcSdk(sdk) || scalarReportValue === "";
+  const { send, isLoading, isSuccess } = useExtrinsic(
+    () => {
+      if (!isRpcSdk(sdk)) return;
 
-  const handleSignTransaction = async () => {
-    const outcomeReport: any = {
-      scalar: new Decimal(scalarReportValue).mul(ZTG).toFixed(0),
-    };
+      const signer = wallet.getActiveSigner();
+      if (!signer) return;
 
-    const signer = wallet.getActiveSigner();
+      const outcomeReport: any = {
+        scalar: new Decimal(scalarReportValue).mul(ZTG).toFixed(0),
+      };
 
-    if (isRpcSdk(sdk) && signer) {
-      const tx = sdk.api.tx.predictionMarkets.report(
+      return sdk.api.tx.predictionMarkets.report(
         market.marketId,
         outcomeReport,
       );
+    },
+    {
+      onSuccess: () => {
+        notificationStore.pushNotification("Outcome Reported", {
+          type: "Success",
+        });
+        onReport?.();
+      },
+    },
+  );
 
-      const callback = extrinsicCallback({
-        api: sdk.api,
-        notifications: notificationStore,
-        successCallback: async () => {
-          notificationStore.pushNotification("Outcome Reported", {
-            type: "Success",
-          });
-          onReport?.();
-        },
-        failCallback: (error) => {
-          notificationStore.pushNotification(error, {
-            type: "Error",
-          });
-        },
-      });
+  const reportDisabled =
+    !sdk ||
+    !isRpcSdk(sdk) ||
+    isLoading ||
+    isSuccess ||
+    scalarReportValue === "";
 
-      signAndSend(tx, signer, callback);
-    }
-  };
+  const handleSignTransaction = async () => send();
 
   return (
     <>


### PR DESCRIPTION
Work needed to consolidate signing and sending of transaction to use useExtrinsic so its easier to implement proxies and possible web2 service for wsx app in the future.

**Note: avatar page has been ommited since I want to deprecate that page because of technical debt in managing nfts that can be done via singular. and listing of badges is on the portfolio page.**