### PR TITLE
Fix market create page accessing proxy when not set

### DIFF
--- a/components/create/editor/inputs/Oracle.tsx
+++ b/components/create/editor/inputs/Oracle.tsx
@@ -68,7 +68,7 @@ export const OracleInput = forwardRef(
     };
 
     const isSelectedAccount = wallet.realAddress === value;
-    const proxy = wallet.proxyFor[wallet.activeAccount.address];
+    const proxy = wallet.proxyFor?.[wallet.activeAccount.address];
     const accountname =
       proxy && proxy.enabled
         ? "Proxied"


### PR DESCRIPTION
Should fix an issue tom reported on the create page after proxies where merged.

![](https://cdn.discordapp.com/attachments/942717533503508540/1127984065388220466/image.png)
