### PR TITLE
Lazy load grill chat

### DIFF
--- a/components/grillchat/index.tsx
+++ b/components/grillchat/index.tsx
@@ -1,29 +1,35 @@
-import React, { useEffect, useRef } from "react";
-import { MessageSquare } from "react-feather";
-import { motion } from "framer-motion";
 import grill from "@subsocial/grill-widget";
+import { motion } from "framer-motion";
+import React, { useState } from "react";
+import { MessageSquare } from "react-feather";
 
 type GrillChatProps = {
-  open: boolean;
-  setOpen: (open: boolean) => void;
   className?: string;
 };
 
-const GrillChat: React.FC<GrillChatProps> = ({ open, setOpen }) => {
-  useEffect(() => {
-    grill.init({
-      theme: "light",
-      channel: {
-        type: "channel",
-        id: "zeitgeist-2052",
-        settings: {
-          enableInputAutofocus: false, // doesn't work
-          enableBackButton: false,
-          enableLoginButton: true,
+const GrillChat: React.FC<GrillChatProps> = () => {
+  const [isInitialised, setIsInitialised] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  const handleClick = () => {
+    if (isInitialised === false) {
+      grill.init({
+        theme: "light",
+        channel: {
+          type: "channel",
+          id: "zeitgeist-2052",
+          settings: {
+            enableInputAutofocus: false, // doesn't work
+            enableBackButton: false,
+            enableLoginButton: true,
+          },
         },
-      },
-    });
-  }, []);
+      });
+      setIsInitialised(true);
+    }
+
+    setOpen(!open);
+  };
 
   return (
     <div
@@ -47,12 +53,12 @@ const GrillChat: React.FC<GrillChatProps> = ({ open, setOpen }) => {
       >
         <div id="grill" className="h-full"></div>
       </motion.div>
-      <div
+      <button
         className="ml-auto rounded-full cursor-pointer border-1 border-gray-300 w-14 h-14 center shadow-ztg-5 bg-white pointer-events-auto mt-4"
-        onClick={() => setOpen(!open)}
+        onClick={handleClick}
       >
         <MessageSquare size={28} />
-      </div>
+      </button>
     </div>
   );
 };

--- a/layouts/DefaultLayout.tsx
+++ b/layouts/DefaultLayout.tsx
@@ -1,4 +1,4 @@
-import { FC, PropsWithChildren, useEffect, useRef, useState } from "react";
+import { FC, PropsWithChildren, useRef, useState } from "react";
 import { useResizeDetector } from "react-resize-detector";
 import Image from "next/image";
 import dynamic from "next/dynamic";
@@ -29,7 +29,6 @@ const DefaultLayout: FC<PropsWithChildren> = ({ children }) => {
   const router = useRouter();
   useSubscribeBlockEvents();
   const [tradeItem, setTradeItem] = useState<TradeItem | null>(null);
-  const [showChat, setShowChat] = useState(false);
 
   const {
     width,
@@ -93,9 +92,7 @@ const DefaultLayout: FC<PropsWithChildren> = ({ children }) => {
       </TradeItemContext.Provider>
       <Account />
       <Onboarding />
-      {process.env.NEXT_PUBLIC_GRILLCHAT_DISABLE !== "true" && (
-        <GrillChat open={showChat} setOpen={setShowChat} />
-      )}
+      {process.env.NEXT_PUBLIC_GRILLCHAT_DISABLE !== "true" && <GrillChat />}
     </div>
   );
 };


### PR DESCRIPTION
Grill chat loads more resources than our index page, so I'm switching it to be lazy loaded. Also stops the console from being clogged up with errors

Index page load without grill chat:
<img width="367" alt="image" src="https://github.com/zeitgeistpm/ui/assets/4950844/abc7861d-4590-4258-a5d8-21c2d98911af">

Index page load with grill chat:
<img width="365" alt="image" src="https://github.com/zeitgeistpm/ui/assets/4950844/1d0f06ef-4279-4ab6-8984-f6e016c23ec1">

Grill chat related errors:
<img width="610" alt="image" src="https://github.com/zeitgeistpm/ui/assets/4950844/e0d46b8e-33f9-4ac7-bf30-3a4a1c86427d">

