### PR TITLE
Long asset name display in buy/sell modals

### DIFF
--- a/components/trade-form/index.tsx
+++ b/components/trade-form/index.tsx
@@ -25,7 +25,13 @@ import { useNotifications } from "lib/state/notifications";
 import { useWallet } from "lib/state/wallet";
 import { TradeType } from "lib/types";
 import { capitalize } from "lodash";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { useForm } from "react-hook-form";
 import { from } from "rxjs";
 import { useDebounce } from "use-debounce";
@@ -38,6 +44,8 @@ import { useSdkv2 } from "lib/hooks/useSdkv2";
 import { awaitIndexer } from "lib/util/await-indexer";
 import Input from "components/ui/Input";
 import { useDelayQueue } from "lib/state/delay-queue";
+import InfoPopover from "components/ui/InfoPopover";
+import TruncatedText from "components/ui/TruncatedText";
 
 const getTradeValuesFromExtrinsicResult = (
   type: TradeType,
@@ -557,7 +565,12 @@ const Inner = ({
               />
             </div>
             <div className="center sm:h-[48px] font-semibold capitalize text-[20px] sm:text-[28px]">
-              {tradeItemState?.asset?.name}
+              <TruncatedText
+                length={24}
+                text={tradeItemState?.asset?.name ?? ""}
+              >
+                {(text) => <>{text}</>}
+              </TruncatedText>
             </div>
             <div className="font-semibold text-center mb-[20px]">For</div>
             <div className="h-[56px] bg-anti-flash-white center text-ztg-18-150 mb-[20px] relative">

--- a/components/ui/InfoPopover.tsx
+++ b/components/ui/InfoPopover.tsx
@@ -24,7 +24,7 @@ export const InfoPopover: React.FC<InfoPopoverProps> = ({
         onClick={() => setIsOpen(true)}
         className="relative justify-center items-center flex md:hidden"
       >
-        <AiOutlineInfoCircle />
+        {icon ?? <AiOutlineInfoCircle />}
       </button>
 
       <Popover className="relative">

--- a/components/ui/TruncatedText.tsx
+++ b/components/ui/TruncatedText.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from "react";
+
+const TruncatedText = (props: {
+  length: number;
+  text: string;
+  children: (text: string) => ReactNode;
+}) => {
+  let isCutOff = props.text?.length > props.length;
+  let cuttofText = `${props.text?.slice(0, props.length)}${
+    isCutOff ? "..." : ""
+  }`;
+
+  return <span title={props.text}>{props.children(cuttofText)}</span>;
+};
+
+export default TruncatedText;


### PR DESCRIPTION
Fixes #1552 

Example market(prod): 198