### PR TITLE
Map identities correctly to jurors

### DIFF
--- a/components/court/JurorsTable.tsx
+++ b/components/court/JurorsTable.tsx
@@ -46,9 +46,7 @@ const columns: TableColumn[] = [
 const JurorsTable = () => {
   const { data: participants } = useCourtParticipants();
   const jurors = participants?.filter((p) => p.type === "Juror");
-  const { data: identities } = useIdentities(
-    participants?.map((j) => j.address),
-  );
+  const { data: identities } = useIdentities(jurors?.map((j) => j.address));
 
   const tableData: TableData[] | undefined = jurors
     ?.filter((p) => p.type === "Juror")


### PR DESCRIPTION
Fixes the bug where the user thought there was a bug with delegations because the identites where mapped to the wrong juror rows.

<img width="1013" alt="Screenshot 2024-02-26 at 11 10 57" src="https://github.com/zeitgeistpm/ui/assets/411755/cfbda3fe-ea77-4b67-8dc5-8ed5e438391c">
