### PR TITLE
Use dedicated onFinality rpc

### DIFF
--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -41,12 +41,7 @@ export const ZTG_CHAIN_ID = "polkadot:1bf2a2ecb4a868de66ea8610f2ce7c8c";
 
 export const endpoints: EndpointOption[] = [
   {
-    value: "wss://zeitgeist-rpc.dwellir.com",
-    label: "Dwellir",
-    environment: "production",
-  },
-  {
-    value: "wss://zeitgeist.api.onfinality.io/public-ws",
+    value: "wss://zeitgeist.api.onfinality.io/ws?apikey=fcfa6c61-e80e-4bb9-b255-44c2c82d0ddb",
     label: "OnFinality",
     environment: "production",
   },


### PR DESCRIPTION
This should allow access to onFinality rpc with higher rate limit. This endpoint would serve to requests originating from `app.zeitgeist.pm` and `staging.zeitgeist.pm`.

Resolves errors thrown by the public rpc endpoint:
![image](https://github.com/user-attachments/assets/b96efe4e-a6a8-4054-9d5f-67abeee03af6)
