### PR TITLE
Increase Minimum Base Liquidity for ZTG

### DIFF
--- a/lib/state/market-creation/constants/currency.ts
+++ b/lib/state/market-creation/constants/currency.ts
@@ -6,7 +6,7 @@ import { SupportedCurrencyTag } from "lib/constants/supported-currencies";
  */
 
 export const minBaseLiquidity: Record<SupportedCurrencyTag, number> = {
-  ZTG: 200,
+  ZTG: 2000,
   DOT: 10,
   USDC: 50,
 };


### PR DESCRIPTION
This PR adjusts the minimum base liquidity for the ZTG currency in the `minBaseLiquidity` configuration. The change updates the value for ZTG from `200` to `2000`, ensuring greater liquidity requirements for markets using ZTG.

### Changes:
- Updated `minBaseLiquidity` in `lib/state/market-creation/constants/currency.ts`:
  - ZTG: 200 → 2000

This update aims to enhance market stability by requiring a higher baseline liquidity for ZTG.